### PR TITLE
Navigation bar animation added

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -15,8 +15,13 @@ const Navigation = () => {
         </p>
       </Link>
 
-      <div className="px-5 py-0.4 text-air-blue-200 text-xl ml-auto font-light">
-        <Link href="/about">About Us</Link>
+      <div className="px-5 py-0.4 text-air-blue-300 text-xl ml-auto mr-20 font-light">
+        <Link href="/about">
+          <p className="group text-blue-500 transition-all duration-500 ease-in-out relative">
+            About Us
+            <span className="absolute bottom-0 left-0 w-0 h-[2px] bg-gradient-to-r from-air-blue-200 to-air-blue-300 transform transition-all duration-500 ease-in-out group-hover:w-full rounded-full"></span>
+          </p>
+        </Link>
       </div>
 
       <div className="rounded-lg px-6 py-1 text-air-blue-200 border-2 border-air-blue-200 text-xl font-medium">


### PR DESCRIPTION
Before hover:
<img width="1800" alt="before_hover" src="https://github.com/UCR-Senior-Design/air-quality/assets/43308867/853a5b29-5a2f-4b36-90cb-fe201b817fbc">

After hover:
<img width="1799" alt="after_hover" src="https://github.com/UCR-Senior-Design/air-quality/assets/43308867/22d2a0e1-fa67-4236-92b7-9f863ad632ae">

- also adjusted spacing between "about us" and the sign in / sign out button 